### PR TITLE
Fixed crashes when a default directory doesn't exist

### DIFF
--- a/picker/find.go
+++ b/picker/find.go
@@ -27,6 +27,7 @@ func findDirectories(searchPaths []string) []list.Item {
 		filepath.WalkDir(expandedRoot, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				fmt.Printf("error while walking dir: %v\n", err)
+				return nil
 			}
 
 			if !d.IsDir() {


### PR DESCRIPTION
The default search paths include searching thru `~` and `~/projects` to start the tool, but if `~/projects` doesn't exist, it will attempt to check for the field `isDir` on https://github.com/e-mar404/tsesh/blob/30799954171fbdb7d90d1df577a49be0ac2f2f5b/picker/find.go#L32 which will cause an application crash.

Added a fix to return early (inside of the an existing guard clause) instead. If there is a specific error that should be checked on instead, let me know, I barely write Go lol.